### PR TITLE
Add deny_rotate=true to learner_uid auth method

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,10 @@ variable "instruqt_user_id" {
 }
 
 resource "akeyless_auth_method_universal_identity" "learner_uid" {
-  name    = format("/instruqt-users-uid/%s/uid-%s", var.instruqt_user_id, var.instruqt_user_id)
-  jwt_ttl = 500
-  ttl     = 500
+  name        = format("/instruqt-users-uid/%s/uid-%s", var.instruqt_user_id, var.instruqt_user_id)
+  jwt_ttl     = 500
+  ttl         = 500
+  deny_rotate = true
 }
 
 resource "akeyless_role" "role" {


### PR DESCRIPTION
Added "deny_rotate = true" to the learner_uid resource to prevent rotation of the universal identity auth method so student's session's wont break in the middle